### PR TITLE
Allow access code 00000

### DIFF
--- a/_bonuscodes/cmr-04.md
+++ b/_bonuscodes/cmr-04.md
@@ -37,6 +37,6 @@ prototypeCheckbox.style.display = 'inline'
 prototypeCheckbox.select_one('label').text = 'Prototype:'
 prototypeCheckbox.select_one('input').value = PROTOTYPE_OPTION
 
-document['access-code'].min = 1
+document['access-code'].min = 0
 document['access-code'].max = cmr04.ACCESS_CODE_MAX
 </script>

--- a/_bonuscodes/cmr-2005.md
+++ b/_bonuscodes/cmr-2005.md
@@ -31,7 +31,7 @@ def onGenerate(ev):
                 yield cheat, cryptedCode
     outputs <= html.DL(html.DIV(html.DT(term + ':') + ' ' + html.DD(code)) for term, code in gen())
 
-document['access-code'].min = 1
+document['access-code'].min = 0
 document['access-code'].max = cmr2005.ACCESS_CODE_MAX
 
 platformSelect = document['platform-select']


### PR DESCRIPTION
In the PS2 version of Colin McRae Rally 2005, if you do not create a profile, the access code is always 00000. I don't know if this is also true for other platforms, and other games by Codemasters.
![00000](https://github.com/user-attachments/assets/7f375de6-440d-4574-9b50-16de169083ac)
